### PR TITLE
fix: Add instructions to get flexbox to work on Safari

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5,6 +5,10 @@ body {
 
 .container {
   width: 100%;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
   display: flex;
   flex-wrap: wrap;
   background-color: #e0e0e0;
@@ -43,7 +47,13 @@ nav a, button {
 }
 
 .menu-box {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
   flex-direction: row;
   flex-wrap: wrap;
   list-style-type: none;
@@ -99,8 +109,6 @@ img, embed, object, video {
   }
   .welcome-msg {
     width: 50%;
-    /* height: 345px;
-    overflow: auto; */
   }
 }
 


### PR DESCRIPTION
Added alternative display instructions to allow flex box to work
cross-browser. My initial tests worked on most browsers and in the
Chrome Developer tools mobile simulator, but did not work on Safari.